### PR TITLE
Replaces version comparison with ternary expression

### DIFF
--- a/engine/Library/Zend/Session.php
+++ b/engine/Library/Zend/Session.php
@@ -558,11 +558,7 @@ class Zend_Session extends Zend_Session_Abstract
             }
         }
 
-        if (version_compare(PHP_VERSION, '7.1', '>=')) {
-            $hashBitsPerChar = ini_get('session.sid_bits_per_character');
-        } else {
-            $hashBitsPerChar = ini_get('session.hash_bits_per_character');
-        }
+        $hashBitsPerChar = ini_get('session.sid_bits_per_character') ?: ini_get('session.hash_bits_per_character');
 
         if (!$hashBitsPerChar) {
             $hashBitsPerChar = 5; // the default value


### PR DESCRIPTION
As suggested by @soebbing in [#1712](https://github.com/shopware/shopware/pull/1712#issuecomment-405528738) this removes the hard check for a specific version of php and instead picks the first ini value that exists.